### PR TITLE
Sync Community Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # https://help.github.com/en/articles/about-code-owners
 * @creativecommons/internal-tech
+* @creativecommons/ct-cc-wordpress-themes-maintainers @creativecommons/ct-cc-wordpress-themes-core-committers


### PR DESCRIPTION
This _automated PR_ updates your CODEOWNERS file to mention all GitHub teams associated with Community Team roles.