### PR TITLE
Restore default settings to Group and Column blocks

### DIFF
--- a/custom-block-settings.js
+++ b/custom-block-settings.js
@@ -29,7 +29,6 @@ const addSpacingControlAttribute = ( settings, name ) => {
             }
         }
     } );
-    console.log(settings);
     return settings;
 };
 

--- a/custom-block-settings.js
+++ b/custom-block-settings.js
@@ -13,14 +13,14 @@ const enableSpacingControlOnBlocks = [
  *
  * @returns {object} Modified block settings.
  */
- const addSpacingControlAttribute = ( settings, name ) => {
+const addSpacingControlAttribute = ( settings, name ) => {
     // Do nothing if it's another block than our defined ones.
     if ( ! enableSpacingControlOnBlocks.includes( name ) ) {
         return settings;
     }
 
-    // Use Lodash's assign to gracefully handle if attributes are undefined
-    settings = lodash.assign( settings, {
+    // Use Lodash's merge to gracefully handle if attributes are undefined
+    settings = lodash.merge( settings, {
         supports: {
             spacing: {
                 blockGap: true,
@@ -29,6 +29,7 @@ const enableSpacingControlOnBlocks = [
             }
         }
     } );
+    console.log(settings);
     return settings;
 };
 


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
Fixes #29 by @MuluhGodson

## Description
This PR adds the default settings to blocks that were extended to support custom spacing settings.

## Screenshots
![image](https://user-images.githubusercontent.com/40151808/145551282-6b1cbb96-c9f5-402d-87d9-53fd0e209c1b.png)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
